### PR TITLE
feat : 게시글 좋아요 관련 엔터티 설계 및 구현

### DIFF
--- a/BE/school/src/main/java/thisisus/school/post/domain/PostLike.java
+++ b/BE/school/src/main/java/thisisus/school/post/domain/PostLike.java
@@ -1,0 +1,26 @@
+package thisisus.school.post.domain;
+
+import lombok.*;
+import thisisus.school.member.domain.Member;
+
+import javax.persistence.*;
+
+@Entity
+@Builder
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostLike {
+    @Id
+    @GeneratedValue
+    @Column(name = "post_like_id")
+    private long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/BE/school/src/test/java/thisisus/school/post/service/PostServiceImplTest.java
+++ b/BE/school/src/test/java/thisisus/school/post/service/PostServiceImplTest.java
@@ -1,0 +1,191 @@
+package thisisus.school.post.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import thisisus.school.member.domain.Member;
+import thisisus.school.member.domain.MemberStatus;
+import thisisus.school.member.domain.Role;
+import thisisus.school.post.domain.Post;
+import thisisus.school.post.domain.PostCategory;
+import thisisus.school.post.dto.PostResponse;
+import thisisus.school.post.dto.PostUpdateRequest;
+import thisisus.school.post.exception.NotCorrectUserException;
+import thisisus.school.post.exception.NotFoundPostException;
+import thisisus.school.post.repository.PostRepository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceImplTest {
+	private Member member;
+	private Member member2;
+	@Mock
+	private PostRepository postRepository;
+	@InjectMocks
+	private PostServiceImpl postService;
+
+	@BeforeEach
+	void setUp() {
+		member = new Member(1L, "장창현",
+			"abcdef@naver.com", "장첸", Role.STUDENT, MemberStatus.ACTIVE,
+			"tempRefresh");
+		member2 = new Member(2L, "테스트용유저",
+			"ghijk@naver.com", "테스트용", Role.STUDENT, MemberStatus.ACTIVE,
+			"tempRefresh2");
+	}
+
+	@Test
+	@DisplayName("post 조회 성공")
+	void findPost() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+		given(postRepository.findById(fakePostId)).willReturn(Optional.ofNullable(post));
+
+		//when
+		PostResponse findPost = postService.findPost(fakePostId);
+
+		//then
+		Assertions.assertEquals(fakePostId, findPost.getPostId());
+		Assertions.assertEquals(member.getNickname(), findPost.getWriter());
+	}
+
+	@Test
+	@DisplayName("MemberId를 통한 Post조회")
+	void findPostByMemberId() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+
+		List<PostResponse> arr = new ArrayList<>();
+		PostResponse postResponse = new PostResponse(post);
+		arr.add(postResponse);
+
+		List<Post> givenArr = new ArrayList<>();
+		givenArr.add(post);
+
+		given(postRepository.findAllByMemberId(member.getId())).willReturn(givenArr);
+
+		//when
+		List<PostResponse> postByMemberId = postService.findPostByMemberId(member.getId());
+
+		//then
+		Assertions.assertEquals(1, postByMemberId.size());
+		Assertions.assertEquals(arr.get(0).getPostId(), postByMemberId.get(0).getPostId());
+	}
+
+	@Test
+	@DisplayName("post 수정 성공")
+	void update() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+		given(postRepository.findById(fakePostId)).willReturn(Optional.ofNullable(post));
+
+		PostUpdateRequest postUpdateRequest = new PostUpdateRequest("수정 테스트 제목", "수정 테스트 내용"
+			, PostCategory.소통해요);
+		//when
+		PostResponse update = postService.update(post.getId(), postUpdateRequest, member.getId());
+		//then
+		Assertions.assertEquals("수정 테스트 제목", update.getTitle());
+	}
+
+	@Test
+	@DisplayName("post 수정 실패 - 작성자 불일치")
+	void failedUpdateByUnCorrectUser() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+		given(postRepository.findById(fakePostId)).willReturn(Optional.ofNullable(post));
+
+		PostUpdateRequest postUpdateRequest = new PostUpdateRequest("수정 테스트 제목", "수정 테스트 내용"
+			, PostCategory.소통해요);
+		//when
+		Assertions.assertThrows(
+			NotCorrectUserException.class, () -> postService.update(post.getId(), postUpdateRequest, member2.getId()));
+
+		//then
+
+	}
+
+	@Test
+	@DisplayName("post 삭제 성공")
+	void delete() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+		given(postRepository.findById(fakePostId)).willReturn(Optional.ofNullable(post));
+		//when
+		postService.delete(fakePostId, member.getId());
+		Post findPost = postRepository.findById(fakePostId).orElseThrow(NotFoundPostException::new);
+		//then
+		Assertions.assertEquals(true, findPost.isDelete());
+	}
+
+	@Test
+	@DisplayName("post 삭제 실패 - 작성자 불일치")
+	void failedDeleteByUnCorrectUser() {
+		//given
+		Long fakePostId = 1L;
+		Post post = Post.builder()
+			.id(fakePostId)
+			.title("테스트 제목")
+			.content("테스트 내용")
+			.likeCount(0)
+			.viewCount(0)
+			.member(member)
+			.build();
+		given(postRepository.findById(fakePostId)).willReturn(Optional.ofNullable(post));
+		//when
+		Assertions.assertThrows(
+			NotCorrectUserException.class, () -> postService.delete(fakePostId, member2.getId()));
+
+		//then
+	}
+}


### PR DESCRIPTION
## #️⃣연관된 이슈 번호
closed #25 

## 📝작업 내용
- 좋아요관련 엔터티를 설계 및 구현 하였습니다.
- softDelete와 hardDelete를 고민하던 중 softDelete를 하더라도 해당 데이터들의 필요성이 없기에 hardDelete를 하기로 결정하였습니다.
- Post와 Member에 대해 단방향 연관관계를 설정하고, N:1 관계를 설정하였습니다.

## 💬리뷰 요구사항

- 이해안가는 부분이 있다면 리뷰달아주세요.