### PR TITLE
feat : refreshToken을 이용한 accessToken 재발급 및 로그아웃

### DIFF
--- a/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
@@ -1,12 +1,22 @@
 package thisisus.school.auth.controller;
 
-import lombok.RequiredArgsConstructor;
+import static org.springframework.boot.web.server.Cookie.SameSite.*;
+import static org.springframework.http.HttpHeaders.*;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.ResponseCookie;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+import thisisus.school.auth.config.AuthenticatedMemberId;
 import thisisus.school.auth.dto.request.SignUpRequest;
 import thisisus.school.auth.dto.response.AuthResponse;
 import thisisus.school.auth.dto.response.IdTokenResponse;
@@ -18,35 +28,68 @@ import thisisus.school.common.response.SuccessResonse;
 @RequestMapping("/api/auth")
 public class AuthController {
 
-    private final AuthService authService;
+	private final AuthService authService;
 
-    @GetMapping("/idToken")
-    public SuccessResonse getIdToken(
-        @RequestParam("code") String code
-    ) {
-        IdTokenResponse idTokenResponse = authService.getIdToken(code);
-        return SuccessResonse.of(idTokenResponse);
-    }
+	@GetMapping("/idToken")
+	public SuccessResonse getIdToken(
+		@RequestParam("code") String code
+	) {
+		IdTokenResponse idTokenResponse = authService.getIdToken(code);
+		return SuccessResonse.of(idTokenResponse);
+	}
 
-    @PostMapping("/login")
-    public SuccessResonse login(
-        @RequestParam("idToken") String idToken
-    ) {
-        AuthResponse authResponse = authService.login(idToken);
-        return SuccessResonse.of(authResponse);
-    }
+	@PostMapping("/sign-up")
+	public SuccessResonse signUp(
+		@RequestParam("idToken") String idToken,
+		@RequestBody SignUpRequest signUpRequest,
+		HttpServletResponse response
+	) {
+		AuthResponse authResponse = authService.signUp(idToken, signUpRequest);
+		ResponseCookie cookie = getCookie(authResponse.getRefreshToken());
+		response.addHeader(SET_COOKIE, cookie.toString());
+		return SuccessResonse.of(authResponse);
+	}
 
-    @PostMapping("/sign-up")
-    public SuccessResonse signUp(
-        @RequestParam("idToken") String idToken,
-        @RequestBody SignUpRequest signUpRequest
-    ) {
-        AuthResponse authResponse = authService.signUp(idToken, signUpRequest);
-        return SuccessResonse.of(authResponse);
-    }
+	@PostMapping("/login")
+	public SuccessResonse login(
+		@RequestParam("idToken") String idToken,
+		HttpServletResponse response
+	) {
+		AuthResponse authResponse = authService.login(idToken);
+		ResponseCookie cookie = getCookie(authResponse.getRefreshToken());
+		response.addHeader(SET_COOKIE, cookie.toString());
+		return SuccessResonse.of(authResponse);
+	}
 
-    @PostMapping("/refresh")
-    public SuccessResonse refreshToken() {
-        return SuccessResonse.of();
-    }
+	@DeleteMapping("/logout")
+	public SuccessResonse logout(
+		@AuthenticatedMemberId Long memberId,
+		String refreshToken
+	) {
+		authService.logout(memberId);
+		return SuccessResonse.of();
+	}
+
+	@PostMapping("/refreshToken")
+	public SuccessResonse refreshToken(
+		@RequestHeader("refresh") String refreshToken,
+		HttpServletResponse response
+	) {
+		AuthResponse authResponse = authService.reissueRefreshToken(refreshToken);
+		ResponseCookie cookie = getCookie(authResponse.getRefreshToken());
+		response.addHeader(SET_COOKIE, cookie.toString());
+		return SuccessResonse.of(authResponse);
+	}
+
+	private ResponseCookie getCookie(
+		final String refreshToken
+	) {
+		ResponseCookie cookie = ResponseCookie.from("REFRESH_TOKEN", refreshToken)
+			.httpOnly(true)
+			.secure(true)
+			.path("/api/admin/auth/reissue-token")
+			.sameSite(NONE.attributeValue())
+			.build();
+		return cookie;
+	}
 }

--- a/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
@@ -63,19 +63,18 @@ public class AuthController {
 
 	@DeleteMapping("/logout")
 	public SuccessResonse logout(
-		@AuthenticatedMemberId Long memberId,
-		String refreshToken
+		@AuthenticatedMemberId Long memberId
 	) {
 		authService.logout(memberId);
 		return SuccessResonse.of();
 	}
 
-	@PostMapping("/refreshToken")
-	public SuccessResonse refreshToken(
+	@PostMapping("/token/reissue")
+	public SuccessResonse reissueToken(
 		@RequestHeader("refresh") String refreshToken,
 		HttpServletResponse response
 	) {
-		AuthResponse authResponse = authService.reissueRefreshToken(refreshToken);
+		AuthResponse authResponse = authService.reissueToken(refreshToken);
 		ResponseCookie cookie = getCookie(authResponse.getRefreshToken());
 		response.addHeader(SET_COOKIE, cookie.toString());
 		return SuccessResonse.of(authResponse);

--- a/BE/school/src/main/java/thisisus/school/auth/exception/AlreadyLoggedOutException.java
+++ b/BE/school/src/main/java/thisisus/school/auth/exception/AlreadyLoggedOutException.java
@@ -1,0 +1,10 @@
+package thisisus.school.auth.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class AlreadyLoggedOutException extends CustomException {
+	public AlreadyLoggedOutException() {
+		super(ExceptionCode.ALREADY_LOGGED_OUT);
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/auth/exception/MemberRefreshTokenMismatchException.java
+++ b/BE/school/src/main/java/thisisus/school/auth/exception/MemberRefreshTokenMismatchException.java
@@ -1,0 +1,10 @@
+package thisisus.school.auth.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class MemberRefreshTokenMismatchException extends CustomException {
+	public MemberRefreshTokenMismatchException() {
+		super(ExceptionCode.MEMBER_REFRESH_TOKEN_MISMATCH);
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/auth/infrastructure/AuthTokenGenerator.java
+++ b/BE/school/src/main/java/thisisus/school/auth/infrastructure/AuthTokenGenerator.java
@@ -1,0 +1,28 @@
+package thisisus.school.auth.infrastructure;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import thisisus.school.auth.dto.response.AuthResponse;
+import thisisus.school.member.domain.Member;
+
+@Component
+@RequiredArgsConstructor
+public class AuthTokenGenerator {
+
+	private final JwtTokenProvider jwtTokenProvider;
+
+	public AuthResponse generate(Member member) {
+		String accessToken = jwtTokenProvider.createAccessToken(member.getId(), member.getRole().name());
+		String refreshToken = jwtTokenProvider.createRefreshToken(member.getId(), member.getRole().name());
+		return new AuthResponse(accessToken, refreshToken);
+	}
+
+	public boolean isValidToken(String token) {
+		return jwtTokenProvider.validateToken(token);
+	}
+
+	public Long extractMemberId(String refreshToken) {
+		return Long.valueOf(jwtTokenProvider.getMemberId(refreshToken));
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/auth/infrastructure/JwtTokenProvider.java
+++ b/BE/school/src/main/java/thisisus/school/auth/infrastructure/JwtTokenProvider.java
@@ -36,7 +36,8 @@ public class JwtTokenProvider {
 
 	@Value("${secret}")
 	private String secretKey;
-	private Long time = 1209600000L;
+	private static long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24;
+	private static long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7;
 
 	private SecretKey key;
 
@@ -61,11 +62,11 @@ public class JwtTokenProvider {
 	}
 
 	public String createAccessToken(Long memberId, String role) {
-		return createToken(memberId, role, "ACEESS_TOKEN", time);
+		return createToken(memberId, role, "ACEESS_TOKEN", ACCESS_TOKEN_EXPIRE_TIME);
 	}
 
 	public String createRefreshToken(Long memberId, String role) {
-		return createToken(memberId, role, "REFRESH_TOKEN", time);
+		return createToken(memberId, role, "REFRESH_TOKEN", REFRESH_TOKEN_EXPIRE_TIME);
 	}
 
 	public String getMemberId(String token) {

--- a/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
@@ -14,5 +14,5 @@ public interface AuthService {
 
 	void logout(Long memberId);
 
-	AuthResponse reissueRefreshToken(String refreshToken);
+	AuthResponse reissueToken(String refreshToken);
 }

--- a/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
@@ -6,10 +6,13 @@ import thisisus.school.auth.dto.response.IdTokenResponse;
 
 public interface AuthService {
 
-    IdTokenResponse getIdToken(String code);
+	IdTokenResponse getIdToken(String code);
 
-    AuthResponse login(String idToken);
+	AuthResponse signUp(String idToken, SignUpRequest signUpRequest);
 
-    AuthResponse signUp(String idToken, SignUpRequest signUpRequest);
+	AuthResponse login(String idToken);
 
+	void logout(Long memberId);
+
+	AuthResponse reissueRefreshToken(String refreshToken);
 }

--- a/BE/school/src/main/java/thisisus/school/auth/service/AuthServiceImpl.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/AuthServiceImpl.java
@@ -81,7 +81,7 @@ public class AuthServiceImpl implements AuthService {
 
 	@Override
 	@Transactional
-	public AuthResponse reissueRefreshToken(final String refreshToken) {
+	public AuthResponse reissueToken(final String refreshToken) {
 		refreshTokenValidator.validateToken(refreshToken);
 		final Long memberId = Long.valueOf(jwtTokenProvider.getMemberId(refreshToken));
 		final Member member = memberRepository.findById(memberId)

--- a/BE/school/src/main/java/thisisus/school/auth/service/AuthServiceImpl.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/AuthServiceImpl.java
@@ -10,12 +10,14 @@ import thisisus.school.auth.dto.response.IdTokenResponse;
 import thisisus.school.auth.dto.response.MemberInfoFromIdToken;
 import thisisus.school.auth.exception.AlreadyRegisteredEmailException;
 import thisisus.school.auth.exception.NotFoundEmailException;
-import thisisus.school.auth.infrastructure.CreateToken;
+import thisisus.school.auth.infrastructure.AuthTokenGenerator;
+import thisisus.school.auth.infrastructure.JwtTokenProvider;
 import thisisus.school.auth.infrastructure.kakao.KakaoProperties;
 import thisisus.school.auth.infrastructure.kakao.KakaoTokenInfoResponse;
 import thisisus.school.auth.infrastructure.kakao.RequestKakaoOauthClient;
 import thisisus.school.auth.processor.LoginByIdTokenProcessor;
 import thisisus.school.member.domain.Member;
+import thisisus.school.member.exception.NotFoundMemberException;
 import thisisus.school.member.repository.MemberRepository;
 
 @Service
@@ -27,11 +29,13 @@ public class AuthServiceImpl implements AuthService {
 	private final RequestKakaoOauthClient requestKakaoOauthClient;
 	private final LoginByIdTokenProcessor loginByIdTokenProcessor;
 	private final KakaoProperties kakaoProperties;
-	private final CreateToken createToken;
+	private final AuthTokenGenerator authTokenGenerator;
+	private final RefreshTokenValidator refreshTokenValidator;
+	private final JwtTokenProvider jwtTokenProvider;
 
 	@Override
-	public IdTokenResponse getIdToken(String code) {
-		KakaoTokenInfoResponse kakaoTokenInfoResponse = requestKakaoOauthClient.getToken(
+	public IdTokenResponse getIdToken(final String code) {
+		final KakaoTokenInfoResponse kakaoTokenInfoResponse = requestKakaoOauthClient.getToken(
 			kakaoProperties.getClientId(),
 			kakaoProperties.getRedirectUrl(),
 			code);
@@ -39,24 +43,13 @@ public class AuthServiceImpl implements AuthService {
 	}
 
 	@Override
-	public AuthResponse login(String idToken) {
-		MemberInfoFromIdToken memberInfoFromIdToken = loginByIdTokenProcessor.getMemberInfoFromIdToken(idToken);
-		if (validateEmail(memberInfoFromIdToken.getEmail())) {
-			Member member = memberRepository.findByEmail(memberInfoFromIdToken.getEmail());
-			return createToken.createAccessToken(member);
-		} else {
-			throw new NotFoundEmailException();
-		}
-	}
-
-	@Override
 	@Transactional
-	public AuthResponse signUp(String idToken, SignUpRequest signUpRequest) {
-		MemberInfoFromIdToken memberInfoFromIdToken = loginByIdTokenProcessor.getMemberInfoFromIdToken(idToken);
+	public AuthResponse signUp(final String idToken, final SignUpRequest signUpRequest) {
+		final MemberInfoFromIdToken memberInfoFromIdToken = loginByIdTokenProcessor.getMemberInfoFromIdToken(idToken);
 		if (!validateEmail(memberInfoFromIdToken.getEmail())) {
 			Member member = signUpRequest.toEntity(memberInfoFromIdToken.getEmail());
 			memberRepository.save(member);
-			AuthResponse authResponse = createToken.createAccessToken(member);
+			AuthResponse authResponse = authTokenGenerator.generate(member);
 			member.setRefreshToken(authResponse.getRefreshToken());
 			return authResponse;
 		} else {
@@ -64,7 +57,43 @@ public class AuthServiceImpl implements AuthService {
 		}
 	}
 
-	private Boolean validateEmail(String email) {
+	@Override
+	@Transactional
+	public AuthResponse login(final String idToken) {
+		final MemberInfoFromIdToken memberInfoFromIdToken = loginByIdTokenProcessor.getMemberInfoFromIdToken(idToken);
+		if (validateEmail(memberInfoFromIdToken.getEmail())) {
+			Member member = memberRepository.findByEmail(memberInfoFromIdToken.getEmail());
+			AuthResponse authResponse = authTokenGenerator.generate(member);
+			member.setRefreshToken(authResponse.getRefreshToken());
+			return authResponse;
+		} else {
+			throw new NotFoundEmailException();
+		}
+	}
+
+	@Override
+	@Transactional
+	public void logout(final Long memberId) {
+		final Member member = memberRepository.findById(memberId).
+			orElseThrow(NotFoundMemberException::new);
+		member.setRefreshToken(null);
+	}
+
+	@Override
+	@Transactional
+	public AuthResponse reissueRefreshToken(final String refreshToken) {
+		refreshTokenValidator.validateToken(refreshToken);
+		final Long memberId = Long.valueOf(jwtTokenProvider.getMemberId(refreshToken));
+		final Member member = memberRepository.findById(memberId)
+			.orElseThrow(NotFoundMemberException::new);
+		refreshTokenValidator.validateLogoutToken(member);
+		refreshTokenValidator.validateTokenOwner(refreshToken, member);
+		AuthResponse authResponse = authTokenGenerator.generate(member);
+		member.setRefreshToken(authResponse.getRefreshToken());
+		return authResponse;
+	}
+
+	private Boolean validateEmail(final String email) {
 		return memberRepository.existsByEmail(email);
 	}
 }

--- a/BE/school/src/main/java/thisisus/school/auth/service/RefreshTokenValidator.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/RefreshTokenValidator.java
@@ -1,0 +1,35 @@
+package thisisus.school.auth.service;
+
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import thisisus.school.auth.exception.AlreadyLoggedOutException;
+import thisisus.school.auth.exception.InvalidTokenException;
+import thisisus.school.auth.exception.MemberRefreshTokenMismatchException;
+import thisisus.school.auth.infrastructure.AuthTokenGenerator;
+import thisisus.school.member.domain.Member;
+
+@RequiredArgsConstructor
+@Component
+public class RefreshTokenValidator {
+
+	private final AuthTokenGenerator authTokenGenerator;
+
+	public void validateToken(String refreshToken) {
+		if (!authTokenGenerator.isValidToken(refreshToken)) {
+			throw new InvalidTokenException();
+		}
+	}
+
+	public void validateTokenOwner(String refreshToken, Member member) {
+		if (!member.getRefreshToken().equals(refreshToken)) {
+			throw new MemberRefreshTokenMismatchException();
+		}
+	}
+
+	public void validateLogoutToken(Member member) {
+		if (member.getRefreshToken().isEmpty()) {
+			throw new AlreadyLoggedOutException();
+		}
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
+++ b/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
@@ -11,20 +11,21 @@ import lombok.Getter;
 @AllArgsConstructor
 public enum ExceptionCode {
 
-  BAD_REQUEST_ERROR(BAD_REQUEST, "잘못된 요청입니다."),
-  INVALID_HTTP_MESSAGE_BODY(BAD_REQUEST, "잘못된 HTTP 요청입니다."),
-  INVALID_JWT_CHARACTER(BAD_REQUEST, "JWT 형식이 유효하지 않습니다."),
-  INVALID_TOKEN(UNAUTHORIZED, "유효하지 않는 토큰입니다."),
-  UNSUPPORTED_HTTP_METHOD(METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
-  NOT_FOUND_MEMBER(NOT_FOUND, "사용자를 찾을 수 없습니다."),
-  NOT_FOUND_EMAIL(NOT_FOUND, "이메일이 존재하지 않습니다."),
-  EXPIRED_TOKEN(UNAUTHORIZED, "토큰이 만료되었습니다."),
-  INCORRECT_TOKEN(UNAUTHORIZED, "올바르지 않는 토큰입니다."),
-  ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),
-  NOT_FOUND_POST(NOT_FOUND, "게시물을 찾을 수 없습니다."),
-  NOT_CORRECT_USER(UNAUTHORIZED, "작성자가 일치하지 않습니다."),
-  PUBLIC_KEY_GENERATION_FAILED(INTERNAL_SERVER_ERROR ,"공개 키 생성에 실패했습니다.");
-  ;
+	BAD_REQUEST_ERROR(BAD_REQUEST, "잘못된 요청입니다."),
+	INVALID_HTTP_MESSAGE_BODY(BAD_REQUEST, "잘못된 HTTP 요청입니다."),
+	INVALID_JWT_CHARACTER(BAD_REQUEST, "JWT 형식이 유효하지 않습니다."),
+	INVALID_TOKEN(UNAUTHORIZED, "유효하지 않는 토큰입니다."),
+	UNSUPPORTED_HTTP_METHOD(METHOD_NOT_ALLOWED, "지원하지 않는 HTTP 메서드입니다."),
+	NOT_FOUND_MEMBER(NOT_FOUND, "사용자를 찾을 수 없습니다."),
+	NOT_FOUND_EMAIL(NOT_FOUND, "이메일이 존재하지 않습니다."),
+	EXPIRED_TOKEN(UNAUTHORIZED, "토큰이 만료되었습니다."),
+	INCORRECT_TOKEN(UNAUTHORIZED, "올바르지 않는 토큰입니다."),
+	ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),
+	ALREADY_LOGGED_OUT(CONFLICT, "이미 로그아웃된 사용자입니다."),
+	NOT_FOUND_POST(NOT_FOUND, "게시물을 찾을 수 없습니다."),
+	NOT_CORRECT_USER(UNAUTHORIZED, "작성자가 일치하지 않습니다."),
+	PUBLIC_KEY_GENERATION_FAILED(INTERNAL_SERVER_ERROR, "공개 키 생성에 실패했습니다."),
+	MEMBER_REFRESH_TOKEN_MISMATCH(FORBIDDEN, "로그인한 사용자의 RefreshToken이 아닙니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
close #26 

## 📝 작업 내용

### 구현 방법
로그아웃
- 사용자가 로그아웃 할 경우 멤버의 refreshToken 필드를 null로 초기화

로그인 
- RefreshToken을 받음
- RefreshToken이 유효하고, 사용자 것인지, 아니면 로그아웃한 상태인지 검증
- 검증이 통과되면 RefreshToken과 AccessToken을 재발급

## 💬 리뷰 요구사항

- 코드 중복을 제거하기 위해 재사용이 잘되어있는지 확인해주세요!