### PR TITLE
feat : 게시글 좋아요, 좋아요 해제 구현 및 테스트코드 작성

### DIFF
--- a/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
+++ b/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
@@ -23,6 +23,7 @@ public enum ExceptionCode {
   ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),
   NOT_FOUND_POST(NOT_FOUND, "게시물을 찾을 수 없습니다."),
   ALREADY_EXIST_POSTLIKE(CONFLICT, "이미 좋아요를 누른 게시물입니다."),
+  NOT_EXIST_POSTLIKE(NOT_FOUND,"해당 게시물에 좋아요 기록이 없습니다."),
   NOT_CORRECT_USER(UNAUTHORIZED, "작성자가 일치하지 않습니다."),
   PUBLIC_KEY_GENERATION_FAILED(INTERNAL_SERVER_ERROR ,"공개 키 생성에 실패했습니다.");
   ;

--- a/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
+++ b/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
@@ -22,6 +22,7 @@ public enum ExceptionCode {
   INCORRECT_TOKEN(UNAUTHORIZED, "올바르지 않는 토큰입니다."),
   ALREADY_REGISTERED_EMAIL(CONFLICT, "이미 등록된 이메일입니다."),
   NOT_FOUND_POST(NOT_FOUND, "게시물을 찾을 수 없습니다."),
+  ALREADY_EXIST_POSTLIKE(CONFLICT, "이미 좋아요를 누른 게시물입니다."),
   NOT_CORRECT_USER(UNAUTHORIZED, "작성자가 일치하지 않습니다."),
   PUBLIC_KEY_GENERATION_FAILED(INTERNAL_SERVER_ERROR ,"공개 키 생성에 실패했습니다.");
   ;

--- a/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
+++ b/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
@@ -11,15 +11,15 @@ import thisisus.school.post.service.PostLikeService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/like")
+@RequestMapping("/api/post/like")
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
     @PostMapping("/{postId}")
-    public SuccessResonse insertLike(@PathVariable("postId") final Long postId,
-                                     @AuthenticatedMemberId final Long memberId) {
-        postLikeService.insertLike(postId, memberId);
+    public SuccessResonse likePost(@PathVariable("postId") final Long postId,
+                                   @AuthenticatedMemberId final Long memberId) {
+        postLikeService.likePost(postId, memberId);
         return SuccessResonse.of();
     }
 }

--- a/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
+++ b/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
@@ -1,10 +1,7 @@
 package thisisus.school.post.controller;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import thisisus.school.auth.config.AuthenticatedMemberId;
 import thisisus.school.common.response.SuccessResonse;
 import thisisus.school.post.service.PostLikeService;
@@ -20,6 +17,13 @@ public class PostLikeController {
     public SuccessResonse likePost(@PathVariable("postId") final Long postId,
                                    @AuthenticatedMemberId final Long memberId) {
         postLikeService.likePost(postId, memberId);
+        return SuccessResonse.of();
+    }
+
+    @DeleteMapping("{postId}")
+    public SuccessResonse disLikePost(@PathVariable("postId") final Long postId,
+                                      @AuthenticatedMemberId final Long memberId) {
+        postLikeService.disLikePost(postId, memberId);
         return SuccessResonse.of();
     }
 }

--- a/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
+++ b/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
@@ -1,0 +1,25 @@
+package thisisus.school.post.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import thisisus.school.auth.config.AuthenticatedMemberId;
+import thisisus.school.common.response.SuccessResonse;
+import thisisus.school.post.service.PostLikeService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/like")
+public class PostLikeController {
+
+    private final PostLikeService postLikeService;
+
+    @PostMapping("/{postId}")
+    public SuccessResonse insertLike(@PathVariable("postId") final Long postId,
+                                     @AuthenticatedMemberId final Long memberId) {
+        postLikeService.insertLike(postId, memberId);
+        return SuccessResonse.of();
+    }
+}

--- a/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
+++ b/BE/school/src/main/java/thisisus/school/post/controller/PostLikeController.java
@@ -8,19 +8,19 @@ import thisisus.school.post.service.PostLikeService;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/post/like")
+@RequestMapping("/api/post")
 public class PostLikeController {
 
     private final PostLikeService postLikeService;
 
-    @PostMapping("/{postId}")
+    @PostMapping("/{postId}/like")
     public SuccessResonse likePost(@PathVariable("postId") final Long postId,
                                    @AuthenticatedMemberId final Long memberId) {
         postLikeService.likePost(postId, memberId);
         return SuccessResonse.of();
     }
 
-    @DeleteMapping("{postId}")
+    @DeleteMapping("{postId}/like")
     public SuccessResonse disLikePost(@PathVariable("postId") final Long postId,
                                       @AuthenticatedMemberId final Long memberId) {
         postLikeService.disLikePost(postId, memberId);

--- a/BE/school/src/main/java/thisisus/school/post/domain/Post.java
+++ b/BE/school/src/main/java/thisisus/school/post/domain/Post.java
@@ -76,4 +76,8 @@ public class Post extends BaseTimeEntity {
     public void increaseLikeCount() {
         this.likeCount = getLikeCount() + 1;
     }
+
+    public void decreaseLikeCount() {
+        this.likeCount = getLikeCount() - 1;
+    }
 }

--- a/BE/school/src/main/java/thisisus/school/post/domain/Post.java
+++ b/BE/school/src/main/java/thisisus/school/post/domain/Post.java
@@ -16,6 +16,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
 import thisisus.school.common.BaseTimeEntity;
 import thisisus.school.member.domain.Member;
 import thisisus.school.post.exception.NotCorrectUserException;
@@ -26,47 +27,53 @@ import thisisus.school.post.exception.NotCorrectUserException;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 public class Post extends BaseTimeEntity {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "post_id")
-	private Long id;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
 
-	@Column
-	private String title;
+    @Column
+    private String title;
 
-	@Column
-	private String content;
+    @Column
+    private String content;
 
-	@Column
-	@Enumerated(EnumType.STRING)
-	private PostCategory category;
+    @Column
+    @Enumerated(EnumType.STRING)
+    private PostCategory category;
 
-	@Column
-	private int likeCount;
+    @Column
+    @ColumnDefault("0")
+    private Integer likeCount;
 
-	@Column
-	private int viewCount;
+    @Column
+    @ColumnDefault("0")
+    private Integer viewCount;
 
-	@Column
-	private boolean isDelete;
+    @Column
+    private boolean isDelete;
 
-	@ManyToOne(fetch = FetchType.LAZY)
-	@JoinColumn(name = "member_id")
-	private Member member;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
 
-	public void delete() {
-		this.isDelete = true;
-	}
+    public void delete() {
+        this.isDelete = true;
+    }
 
-	public void update(String title, String content, PostCategory category) {
-		this.title = title;
-		this.content = content;
-		this.category = category;
-	}
+    public void update(String title, String content, PostCategory category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
 
-	public void checkWriter(Post post, Long memberId) {
-		if (post.getMember().getId() != memberId) {
-			throw new NotCorrectUserException();
-		}
-	}
+    public void checkWriter(Post post, Long memberId) {
+        if (post.getMember().getId() != memberId) {
+            throw new NotCorrectUserException();
+        }
+    }
+
+    public void increaseLikeCount() {
+        this.likeCount = getLikeCount() + 1;
+    }
 }

--- a/BE/school/src/main/java/thisisus/school/post/exception/AlreadyExistPostLikeException.java
+++ b/BE/school/src/main/java/thisisus/school/post/exception/AlreadyExistPostLikeException.java
@@ -1,0 +1,10 @@
+package thisisus.school.post.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class AlreadyExistPostLikeException extends CustomException {
+    public AlreadyExistPostLikeException() {
+        super(ExceptionCode.ALREADY_EXIST_POSTLIKE);
+    }
+}

--- a/BE/school/src/main/java/thisisus/school/post/exception/NotExistPostLikeException.java
+++ b/BE/school/src/main/java/thisisus/school/post/exception/NotExistPostLikeException.java
@@ -1,0 +1,10 @@
+package thisisus.school.post.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class NotExistPostLikeException extends CustomException {
+    public NotExistPostLikeException() {
+        super(ExceptionCode.NOT_EXIST_POSTLIKE);
+    }
+}

--- a/BE/school/src/main/java/thisisus/school/post/repository/PostLikeRepository.java
+++ b/BE/school/src/main/java/thisisus/school/post/repository/PostLikeRepository.java
@@ -11,4 +11,6 @@ import java.util.Optional;
 @Repository
 public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
     boolean existsByMemberAndPost(Member member, Post post);
+
+    PostLike findByMemberAndPost(Member member, Post post);
 }

--- a/BE/school/src/main/java/thisisus/school/post/repository/PostLikeRepository.java
+++ b/BE/school/src/main/java/thisisus/school/post/repository/PostLikeRepository.java
@@ -1,0 +1,14 @@
+package thisisus.school.post.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import thisisus.school.member.domain.Member;
+import thisisus.school.post.domain.Post;
+import thisisus.school.post.domain.PostLike;
+
+import java.util.Optional;
+
+@Repository
+public interface PostLikeRepository extends JpaRepository<PostLike, Long> {
+    boolean existsByMemberAndPost(Member member, Post post);
+}

--- a/BE/school/src/main/java/thisisus/school/post/repository/PostRepository.java
+++ b/BE/school/src/main/java/thisisus/school/post/repository/PostRepository.java
@@ -1,10 +1,16 @@
 package thisisus.school.post.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import thisisus.school.post.domain.Post;
 
+import javax.persistence.LockModeType;
 import java.util.List;
+import java.util.Optional;
 
 public interface PostRepository extends JpaRepository<Post, Long> {
     List<Post> findAllByMemberId(Long memberId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Post> findWithLockById(Long id);
 }

--- a/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
+++ b/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
@@ -1,0 +1,5 @@
+package thisisus.school.post.service;
+
+public interface PostLikeService {
+    void insertLike(Long postId, Long memberId);
+}

--- a/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
+++ b/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
@@ -1,5 +1,5 @@
 package thisisus.school.post.service;
 
 public interface PostLikeService {
-    void insertLike(Long postId, Long memberId);
+    void likePost(Long postId, Long memberId);
 }

--- a/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
+++ b/BE/school/src/main/java/thisisus/school/post/service/PostLikeService.java
@@ -2,4 +2,5 @@ package thisisus.school.post.service;
 
 public interface PostLikeService {
     void likePost(Long postId, Long memberId);
+    void disLikePost(Long postId, Long memberId);
 }

--- a/BE/school/src/main/java/thisisus/school/post/service/PostLikeServiceImpl.java
+++ b/BE/school/src/main/java/thisisus/school/post/service/PostLikeServiceImpl.java
@@ -1,0 +1,43 @@
+package thisisus.school.post.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import thisisus.school.member.domain.Member;
+import thisisus.school.member.exception.NotFoundMemberException;
+import thisisus.school.member.repository.MemberRepository;
+import thisisus.school.post.domain.Post;
+import thisisus.school.post.domain.PostLike;
+import thisisus.school.post.exception.AlreadyExistPostLikeException;
+import thisisus.school.post.exception.NotFoundPostException;
+import thisisus.school.post.repository.PostLikeRepository;
+import thisisus.school.post.repository.PostRepository;
+
+@Service
+@RequiredArgsConstructor
+public class PostLikeServiceImpl implements PostLikeService {
+    private final PostLikeRepository postLikeRepository;
+    private final PostRepository postRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    @Transactional
+    public synchronized void insertLike(Long postId, Long memberId) {
+        Member member = memberRepository.findById(memberId)
+                .orElseThrow(NotFoundMemberException::new);
+        Post post = postRepository.findWithLockById(postId)
+                .orElseThrow(NotFoundPostException::new);
+        if (postLikeRepository.existsByMemberAndPost(member, post)) {
+            throw new AlreadyExistPostLikeException();
+        }
+        post.increaseLikeCount();
+        postRepository.save(post);
+
+        PostLike postLike = PostLike.builder()
+                .post(post)
+                .member(member)
+                .build();
+
+        postLikeRepository.save(postLike);
+    }
+}

--- a/BE/school/src/main/java/thisisus/school/post/service/PostLikeServiceImpl.java
+++ b/BE/school/src/main/java/thisisus/school/post/service/PostLikeServiceImpl.java
@@ -22,7 +22,7 @@ public class PostLikeServiceImpl implements PostLikeService {
 
     @Override
     @Transactional
-    public synchronized void insertLike(Long postId, Long memberId) {
+    public synchronized void likePost(Long postId, Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(NotFoundMemberException::new);
         Post post = postRepository.findWithLockById(postId)

--- a/BE/school/src/test/java/thisisus/school/post/service/PostLikeServiceImplTest.java
+++ b/BE/school/src/test/java/thisisus/school/post/service/PostLikeServiceImplTest.java
@@ -1,0 +1,146 @@
+package thisisus.school.post.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import thisisus.school.member.domain.Member;
+import thisisus.school.member.domain.MemberStatus;
+import thisisus.school.member.domain.Role;
+import thisisus.school.member.exception.NotFoundMemberException;
+import thisisus.school.member.repository.MemberRepository;
+import thisisus.school.post.domain.Post;
+import thisisus.school.post.domain.PostCategory;
+import thisisus.school.post.domain.PostLike;
+import thisisus.school.post.exception.AlreadyExistPostLikeException;
+import thisisus.school.post.exception.NotFoundPostException;
+import thisisus.school.post.repository.PostLikeRepository;
+import thisisus.school.post.repository.PostRepository;
+
+import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class PostLikeServiceImplTest {
+
+    @Mock
+    PostLikeRepository postLikeRepository;
+
+    @Mock
+    PostRepository postRepository;
+
+    @Mock
+    MemberRepository memberRepository;
+
+    @InjectMocks
+    PostLikeServiceImpl postLikeService;
+
+    private Member member;
+    private Post post;
+    private PostLike postLike;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member(1L, "장창현",
+                "abcdef@naver.com", "장첸", Role.STUDENT, MemberStatus.ACTIVE,
+                "tempRefresh");
+        post = new Post(1L, "테스트용 제목", "테스트용 내용",
+                PostCategory.소통해요, 0, 0, false, member);
+        postLike = PostLike.builder().member(member).post(post).build();
+    }
+
+    @Test
+    @DisplayName("좋아요 insert - 성공")
+    void insertPostLike() {
+        //given
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postLikeRepository.existsByMemberAndPost(member, post)).thenReturn(false);
+        when(postLikeRepository.save(any(PostLike.class))).thenReturn(postLike);
+
+        //when
+        postLikeService.insertLike(1L, 1L);
+
+        //then
+        verify(memberRepository).findById(1L);
+        verify(postRepository).findById(1L);
+        verify(postLikeRepository).existsByMemberAndPost(member, post);
+        verify(postLikeRepository).save(any(PostLike.class));
+        Assertions.assertEquals(1, post.getLikeCount());
+    }
+
+    @Test
+    @DisplayName("좋아요 insert - 잘못된 postId로 인한 실패")
+    void failedInsertPostLikeByWrongPostId() {
+        // given
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(postRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(NotFoundPostException.class, () -> postLikeService.insertLike(1L, 1L));
+    }
+
+    @Test
+    @DisplayName("좋아요 insert - 잘못된 memberId로 인한 실패")
+    void failedInsertPostLikeByWrongMemberId() {
+        // given
+        when(memberRepository.findById(1L)).thenReturn(Optional.empty());
+
+        // then
+        assertThrows(NotFoundMemberException.class, () -> postLikeService.insertLike(1L, 1L));
+    }
+
+    @Test
+    @DisplayName("좋아요 insert - 이미 좋아요를 누른 post인 경우")
+    void failedInsertPostLikeByAlreadyExistPostLike() {
+        // given
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postLikeRepository.existsByMemberAndPost(member, post)).thenReturn(true);
+
+        // then
+        assertThrows(AlreadyExistPostLikeException.class, () -> postLikeService.insertLike(1L, 1L));
+    }
+
+    // 차이가 나긴 하지만 메모리상에 위치하는 Mock객체를 이용해서 그런지 차이가 매우 극소량 났다.
+    // 또한 실제 DB에 접근하여 물리적인 행위가 안나오니 크게 오차가 없는것 같다.
+    // 그래서 DB에 실제 접근하는 테스트코드를 작성하기로 했다.
+    @Test
+    @DisplayName("좋아요 기능에 대한 동시성 테스트")
+    void synchronousTestAboutPostLike() throws InterruptedException {
+        int numberOfThreads = 1000;
+        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+
+        when(memberRepository.findById(1L)).thenReturn(Optional.of(member));
+        when(postRepository.findById(1L)).thenReturn(Optional.of(post));
+        when(postLikeRepository.existsByMemberAndPost(member, post)).thenReturn(false);
+        when(postLikeRepository.save(any(PostLike.class))).thenReturn(postLike);
+
+        for (int i = 0; i < numberOfThreads; i++) {
+            executorService.submit(() -> {
+                try {
+                    postLikeService.insertLike(1L, 1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+
+        }
+        latch.await();
+
+        assertEquals(numberOfThreads, post.getLikeCount());
+    }
+
+}

--- a/BE/school/src/test/java/thisisus/school/post/service/PostLikeServiceImplTest.java
+++ b/BE/school/src/test/java/thisisus/school/post/service/PostLikeServiceImplTest.java
@@ -25,7 +25,6 @@ import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -70,7 +69,7 @@ class PostLikeServiceImplTest {
         when(postLikeRepository.save(any(PostLike.class))).thenReturn(postLike);
 
         //when
-        postLikeService.insertLike(1L, 1L);
+        postLikeService.likePost(1L, 1L);
 
         //then
         verify(memberRepository).findById(1L);
@@ -88,7 +87,7 @@ class PostLikeServiceImplTest {
         when(postRepository.findById(1L)).thenReturn(Optional.empty());
 
         // then
-        assertThrows(NotFoundPostException.class, () -> postLikeService.insertLike(1L, 1L));
+        assertThrows(NotFoundPostException.class, () -> postLikeService.likePost(1L, 1L));
     }
 
     @Test
@@ -98,7 +97,7 @@ class PostLikeServiceImplTest {
         when(memberRepository.findById(1L)).thenReturn(Optional.empty());
 
         // then
-        assertThrows(NotFoundMemberException.class, () -> postLikeService.insertLike(1L, 1L));
+        assertThrows(NotFoundMemberException.class, () -> postLikeService.likePost(1L, 1L));
     }
 
     @Test
@@ -110,7 +109,7 @@ class PostLikeServiceImplTest {
         when(postLikeRepository.existsByMemberAndPost(member, post)).thenReturn(true);
 
         // then
-        assertThrows(AlreadyExistPostLikeException.class, () -> postLikeService.insertLike(1L, 1L));
+        assertThrows(AlreadyExistPostLikeException.class, () -> postLikeService.likePost(1L, 1L));
     }
 
     // 차이가 나긴 하지만 메모리상에 위치하는 Mock객체를 이용해서 그런지 차이가 매우 극소량 났다.
@@ -131,7 +130,7 @@ class PostLikeServiceImplTest {
         for (int i = 0; i < numberOfThreads; i++) {
             executorService.submit(() -> {
                 try {
-                    postLikeService.insertLike(1L, 1L);
+                    postLikeService.likePost(1L, 1L);
                 } finally {
                     latch.countDown();
                 }

--- a/BE/school/src/test/java/thisisus/school/post/service/PostLikeSynchronousTest.java
+++ b/BE/school/src/test/java/thisisus/school/post/service/PostLikeSynchronousTest.java
@@ -1,0 +1,94 @@
+package thisisus.school.post.service;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import thisisus.school.member.domain.Member;
+import thisisus.school.member.domain.MemberStatus;
+import thisisus.school.member.domain.Role;
+import thisisus.school.member.repository.MemberRepository;
+import thisisus.school.post.domain.Post;
+import thisisus.school.post.domain.PostCategory;
+import thisisus.school.post.repository.PostRepository;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringBootTest
+public class PostLikeSynchronousTest {
+    @Autowired
+    MemberRepository memberRepository;
+
+    @Autowired
+    PostRepository postRepository;
+
+    @Autowired
+    PostLikeServiceImpl postLikeService;
+
+    private Member member;
+    private Member member2;
+    private Post post;
+
+    @BeforeEach
+    void setUp() {
+        member = new Member(1L, "장창현",
+                "abcdef@naver.com", "장첸", Role.STUDENT, MemberStatus.ACTIVE,
+                "tempRefresh");
+        member2 = new Member(2L, "윤후중",
+                "sdfsdf@naver.com", "윤후", Role.STUDENT, MemberStatus.ACTIVE,
+                "tempRefresh2");
+        memberRepository.save(member);
+        memberRepository.save(member2);
+        post = new Post(1L, "테스트용 제목", "테스트용 내용",
+                PostCategory.소통해요, 0, 0, false, member);
+        postRepository.save(post);
+    }
+
+    @Test
+    @DisplayName("좋아요 기능에 대한 동시성 테스트2")
+    void db를_이용한_동시성_테스트() throws InterruptedException {
+        ExecutorService executorService = Executors.newFixedThreadPool(2);
+        CountDownLatch latch = new CountDownLatch(2);
+        executorService.execute(() -> {
+            postLikeService.insertLike(1L, member.getId());
+            latch.countDown();
+        });
+
+        executorService.execute(() -> {
+            postLikeService.insertLike(1L, member2.getId());
+            latch.countDown();
+        });
+        latch.await();
+        Post post1 = postRepository.findById(1L).orElseThrow(RuntimeException::new);
+        Assertions.assertEquals(2, post1.getLikeCount());
+    }
+
+    // PostLike에 insert를 안하고 post의 likecount에 대해서만 update를 수행할때
+//    @Test
+//    @DisplayName("좋아요 기능에 대한 동시성 테스트3")
+//    void db를_이용한_동시성_테스트2() throws InterruptedException{
+//        int numberOfThreads = 100;
+//        ExecutorService executorService = Executors.newFixedThreadPool(numberOfThreads);
+//        CountDownLatch latch = new CountDownLatch(numberOfThreads);
+//
+//        for (int i = 0; i < numberOfThreads; i++) {
+//            executorService.submit(() -> {
+//                try {
+//                    postLikeService.insertLike(1L, 1L);
+//                } finally {
+//                    latch.countDown();
+//                }
+//            });
+//
+//        }
+//        latch.await();
+//        Post post1 = postRepository.findById(1L).orElseThrow(RuntimeException::new);
+//        assertEquals(numberOfThreads, post1.getLikeCount());
+//    }
+}

--- a/BE/school/src/test/java/thisisus/school/post/service/PostLikeSynchronousTest.java
+++ b/BE/school/src/test/java/thisisus/school/post/service/PostLikeSynchronousTest.java
@@ -56,12 +56,12 @@ public class PostLikeSynchronousTest {
         ExecutorService executorService = Executors.newFixedThreadPool(2);
         CountDownLatch latch = new CountDownLatch(2);
         executorService.execute(() -> {
-            postLikeService.insertLike(1L, member.getId());
+            postLikeService.likePost(1L, member.getId());
             latch.countDown();
         });
 
         executorService.execute(() -> {
-            postLikeService.insertLike(1L, member2.getId());
+            postLikeService.likePost(1L, member2.getId());
             latch.countDown();
         });
         latch.await();


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
close #25 

## 📝 작업 내용
- 사용자가 좋아요 버튼을 눌렀을 때, 해당 게시물의 좋아요 갯수가 증가하고 PostLike에 데이터가 생성되도록 구현했습니다.
- 이때 발생할 수 있는 동시성이슈를 테스트 코드를 통해 확인하고 synchronous, 비관적 락, join등 여러 해결방안 중 현재 프로젝트 상황에 맞다고 생각한 비관적 락을 선택하여 해결하였습니다.
- 차후 redis를 도입하면 그때 redis를 이용한 동시성 이슈 해결을 도입하겠습니다.
- 사용자가 좋아요된 상태의 버튼을 눌렀을 때, 해당 게시물의 좋아요 갯수가 감소하고 PostLike에 데이터가 hardDelete되도록 구현했습니다.

## 💬 리뷰 요구사항
- wrapper클래스를 사용하지 않은 부분들이 있거나 굳이 작성하지 않아도 되는 코드가 있다면 리뷰해주세요.
