### PR TITLE
refactor : Redis를 이용해서 RefreshToken 관리 및 OIDC Key를 캐싱하여 관리

### DIFF
--- a/BE/school/src/main/java/thisisus/school/auth/config/AuthenticationExtractor.java
+++ b/BE/school/src/main/java/thisisus/school/auth/config/AuthenticationExtractor.java
@@ -17,11 +17,6 @@ public class AuthenticationExtractor {
     return extract(headers);
   }
 
-  public static String extractRefreshToken(HttpServletRequest request) {
-    Enumeration<String> headers = request.getHeaders("Refresh-Token");
-    return extract(headers);
-  }
-
   private static String extract(Enumeration<String> headers) {
     while (headers.hasMoreElements()) {
       String value = headers.nextElement();
@@ -37,5 +32,4 @@ public class AuthenticationExtractor {
     }
     return null;
   }
-
 }

--- a/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
@@ -4,6 +4,7 @@ import static org.springframework.boot.web.server.Cookie.SameSite.*;
 import static org.springframework.http.HttpHeaders.*;
 
 import javax.servlet.http.HttpServletResponse;
+import javax.validation.Valid;
 
 import org.springframework.http.ResponseCookie;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -41,7 +42,7 @@ public class AuthController {
 	@PostMapping("/sign-up")
 	public SuccessResonse signUp(
 		@RequestParam("idToken") String idToken,
-		@RequestBody SignUpRequest signUpRequest,
+		@RequestBody @Valid SignUpRequest signUpRequest,
 		HttpServletResponse response
 	) {
 		AuthResponse authResponse = authService.signUp(idToken, signUpRequest);

--- a/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/AuthController.java
@@ -63,9 +63,9 @@ public class AuthController {
 
 	@DeleteMapping("/logout")
 	public SuccessResonse logout(
-		@AuthenticatedMemberId Long memberId
+		@RequestHeader("refresh") String refreshToken
 	) {
-		authService.logout(memberId);
+		authService.logout(refreshToken);
 		return SuccessResonse.of();
 	}
 

--- a/BE/school/src/main/java/thisisus/school/auth/controller/AuthenticatedMemberResolver.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/AuthenticatedMemberResolver.java
@@ -33,6 +33,7 @@ public class AuthenticatedMemberResolver implements HandlerMethodArgumentResolve
         if (token == null) {
             throw new InvalidTokenException();
         }
+        jwtTokenProvider.validateToken(token, "ACEESS_TOKEN");
         return Long.valueOf(jwtTokenProvider.getMemberId(token));
     }
 }

--- a/BE/school/src/main/java/thisisus/school/auth/controller/interceptor/AuthenticationInterceptor.java
+++ b/BE/school/src/main/java/thisisus/school/auth/controller/interceptor/AuthenticationInterceptor.java
@@ -29,9 +29,8 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
         }
 
         final String token = AuthenticationExtractor.extractAccessToken(request);
-        jwtTokenProvider.validateToken(token);
+        jwtTokenProvider.validateToken(token,"ACEESS_TOKEN");
 
         return true;
     }
-
 }

--- a/BE/school/src/main/java/thisisus/school/auth/dto/request/SignUpRequest.java
+++ b/BE/school/src/main/java/thisisus/school/auth/dto/request/SignUpRequest.java
@@ -1,11 +1,23 @@
 package thisisus.school.auth.dto.request;
 
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import thisisus.school.member.domain.Member;
 import thisisus.school.member.domain.Role;
 
 public record SignUpRequest(
+    @NotNull(message = "사용자 이름은 빈칸일 수가 없습니다.")
+    @NotBlank(message = "사용자 이름은 공백일 수가 없습니다.")
+    @Size(min = 2, max = 10, message = "사용자 이름은 2 ~ 10 사이어야 합니다.")
     String name,
+    @NotNull(message = "역할은 빈칸일 수가 없습니다.")
+    @NotBlank(message = "역할은 공백일 수가 없습니다.")
     Role role,
+    @NotNull(message = "닉네임은 빈칸일 수가 없습니다.")
+    @NotBlank(message = "닉네임은 공백일 수가 없습니다.")
+    @Size(min = 1, max = 15, message = "닉네임은 1 ~ 15자 사이어야 합니다.")
     String nickname
 ) {
 

--- a/BE/school/src/main/java/thisisus/school/auth/exception/TokenTypeMismatchException.java
+++ b/BE/school/src/main/java/thisisus/school/auth/exception/TokenTypeMismatchException.java
@@ -1,0 +1,10 @@
+package thisisus.school.auth.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class TokenTypeMismatchException extends CustomException {
+	public TokenTypeMismatchException() {
+		super(ExceptionCode.TOKEN_TYPE_MISMATCH);
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/auth/infrastructure/AuthTokenGenerator.java
+++ b/BE/school/src/main/java/thisisus/school/auth/infrastructure/AuthTokenGenerator.java
@@ -19,10 +19,6 @@ public class AuthTokenGenerator {
 	}
 
 	public boolean isValidToken(String token) {
-		return jwtTokenProvider.validateToken(token);
-	}
-
-	public Long extractMemberId(String refreshToken) {
-		return Long.valueOf(jwtTokenProvider.getMemberId(refreshToken));
+		return jwtTokenProvider.validateToken(token, "REFRESH_TOKEN");
 	}
 }

--- a/BE/school/src/main/java/thisisus/school/auth/infrastructure/JwtTokenProvider.java
+++ b/BE/school/src/main/java/thisisus/school/auth/infrastructure/JwtTokenProvider.java
@@ -27,6 +27,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import thisisus.school.auth.dto.response.MemberInfoFromIdToken;
 import thisisus.school.auth.exception.InvalidTokenException;
+import thisisus.school.auth.exception.TokenTypeMismatchException;
 import thisisus.school.common.exception.CustomException;
 
 @Component
@@ -117,9 +118,17 @@ public class JwtTokenProvider {
 		}
 	}
 
-	public boolean validateToken(String token) {
+	public boolean validateToken(String token, String type) {
 		try {
-			Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+			Claims claims = Jwts.parserBuilder()
+				.setSigningKey(key)
+				.build()
+				.parseClaimsJws(token)
+				.getBody();
+			String tokenType = claims.get("type", String.class);
+			if (!tokenType.equals(type)) {
+				throw new TokenTypeMismatchException();
+			}
 			return true;
 		} catch (SignatureException e) {
 			throw new CustomException(INVALID_JWT_CHARACTER);

--- a/BE/school/src/main/java/thisisus/school/auth/infrastructure/kakao/RequestKakaoOauthClient.java
+++ b/BE/school/src/main/java/thisisus/school/auth/infrastructure/kakao/RequestKakaoOauthClient.java
@@ -1,5 +1,6 @@
 package thisisus.school.auth.infrastructure.kakao;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -16,6 +17,7 @@ public interface RequestKakaoOauthClient {
       @RequestParam("code") String code
   );
 
+  @Cacheable(cacheNames = "KakaoOIDC", cacheManager = "oidcCacheManager")
   @GetMapping("/.well-known/jwks.json")
   PublicKeysDto getPublicKeys();
 }

--- a/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/AuthService.java
@@ -12,7 +12,7 @@ public interface AuthService {
 
 	AuthResponse login(String idToken);
 
-	void logout(Long memberId);
+	void logout(String refreshToken);
 
 	AuthResponse reissueToken(String refreshToken);
 }

--- a/BE/school/src/main/java/thisisus/school/auth/service/RefreshTokenValidator.java
+++ b/BE/school/src/main/java/thisisus/school/auth/service/RefreshTokenValidator.java
@@ -8,7 +8,6 @@ import thisisus.school.auth.exception.InvalidTokenException;
 import thisisus.school.auth.exception.MemberRefreshTokenMismatchException;
 import thisisus.school.auth.infrastructure.AuthTokenGenerator;
 import thisisus.school.redis.Auth.domain.RefreshToken;
-import thisisus.school.redis.Auth.repository.RefreshTokenRedisRepository;
 import thisisus.school.redis.Auth.service.RefreshTokenRedisService;
 
 @RequiredArgsConstructor
@@ -16,7 +15,6 @@ import thisisus.school.redis.Auth.service.RefreshTokenRedisService;
 public class RefreshTokenValidator {
 
 	private final AuthTokenGenerator authTokenGenerator;
-	private final RefreshTokenRedisRepository refreshTokenRedisRepository;
 	private final RefreshTokenRedisService refreshTokenRedisService;
 
 	public void validateToken(final String refreshToken) {
@@ -34,7 +32,7 @@ public class RefreshTokenValidator {
 	}
 
 	public void validateLogoutToken(final String refreshToken) {
-		if (refreshTokenRedisRepository.findByKey(refreshToken).isEmpty()) {
+		if (refreshTokenRedisService.findByKey(refreshToken).equals(null)) {
 			throw new AlreadyLoggedOutException();
 		}
 	}

--- a/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
+++ b/BE/school/src/main/java/thisisus/school/common/exception/ExceptionCode.java
@@ -25,6 +25,7 @@ public enum ExceptionCode {
 	NOT_FOUND_POST(NOT_FOUND, "게시물을 찾을 수 없습니다."),
 	NOT_CORRECT_USER(UNAUTHORIZED, "작성자가 일치하지 않습니다."),
 	PUBLIC_KEY_GENERATION_FAILED(INTERNAL_SERVER_ERROR, "공개 키 생성에 실패했습니다."),
+	TOKEN_TYPE_MISMATCH(FORBIDDEN, "토큰 타입이 잘못되었습니다."),
 	MEMBER_REFRESH_TOKEN_MISMATCH(FORBIDDEN, "로그인한 사용자의 RefreshToken이 아닙니다.");
 
 	private final HttpStatus httpStatus;

--- a/BE/school/src/main/java/thisisus/school/member/controller/MemberController.java
+++ b/BE/school/src/main/java/thisisus/school/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package thisisus.school.member.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -24,7 +26,7 @@ public class MemberController {
 	@PatchMapping("/update")
 	public SuccessResonse updateMember(
 		@AuthenticatedMemberId final Long memberId,
-		@RequestBody UpdateMemberRequest updateMemberRequest
+		@RequestBody @Valid UpdateMemberRequest updateMemberRequest
 	) {
 		memberService.update(memberId, updateMemberRequest);
 		return SuccessResonse.of();

--- a/BE/school/src/main/java/thisisus/school/member/domain/Member.java
+++ b/BE/school/src/main/java/thisisus/school/member/domain/Member.java
@@ -6,6 +6,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,38 +20,33 @@ import lombok.ToString;
 @AllArgsConstructor
 public class Member {
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-    private String name;
-    private String email;
-    private String nickname;
-    @Enumerated(EnumType.STRING)
-    private Role role;
-    @Enumerated(EnumType.STRING)
-    private MemberStatus memberStatus;
-    private String refreshToken;
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+	private String name;
+	private String email;
+	private String nickname;
+	@Enumerated(EnumType.STRING)
+	private Role role;
+	@Enumerated(EnumType.STRING)
+	private MemberStatus memberStatus;
 
-    @Builder
-    public Member(String name, String email, String nickname, Role role) {
-        this.name = name;
-        this.email = email;
-        this.nickname = nickname;
-        this.role = role;
-        this.memberStatus = MemberStatus.ACTIVE;
-    }
+	@Builder
+	public Member(String name, String email, String nickname, Role role) {
+		this.name = name;
+		this.email = email;
+		this.nickname = nickname;
+		this.role = role;
+		this.memberStatus = MemberStatus.ACTIVE;
+	}
 
-    public void delete() {
-        this.memberStatus = MemberStatus.DELETED;
-        this.email = null;
-    }
+	public void delete() {
+		this.memberStatus = MemberStatus.DELETED;
+		this.email = null;
+	}
 
-    public void update(String nickname, Role role) {
-        this.nickname = nickname;
-        this.role = role;
-    }
-
-    public void setRefreshToken(String refreshToken) {
-        this.refreshToken = refreshToken;
-    }
+	public void update(String nickname, Role role) {
+		this.nickname = nickname;
+		this.role = role;
+	}
 }

--- a/BE/school/src/main/java/thisisus/school/member/dto/UpdateMemberRequest.java
+++ b/BE/school/src/main/java/thisisus/school/member/dto/UpdateMemberRequest.java
@@ -2,15 +2,17 @@ package thisisus.school.member.dto;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import thisisus.school.member.domain.Role;
 
 public record UpdateMemberRequest(
-	@NotNull
-	@NotBlank
+	@NotNull(message = "닉네임은 빈칸일 수가 없습니다.")
+	@NotBlank(message = "닉네임은 공백일 수가 없습니다.")
+	@Size(min = 1, max = 15, message = "닉네임은 1 ~ 15자 사이어야 합니다.")
 	String nickname,
-	@NotNull
-	@NotBlank
+	@NotNull(message = "역할은 빈칸일 수가 없습니다.")
+	@NotBlank(message = "역할은 공백일 수가 없습니다.")
 	Role role
 ) {
 

--- a/BE/school/src/main/java/thisisus/school/redis/Auth/domain/RefreshToken.java
+++ b/BE/school/src/main/java/thisisus/school/redis/Auth/domain/RefreshToken.java
@@ -1,0 +1,21 @@
+package thisisus.school.redis.Auth.domain;
+
+import org.springframework.data.annotation.Id;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PUBLIC)
+@Builder
+@Getter
+public class RefreshToken {
+
+	@Id
+	private String refreshToken;
+	private Long memberId;
+
+}

--- a/BE/school/src/main/java/thisisus/school/redis/Auth/exception/ExpiredTokenException.java
+++ b/BE/school/src/main/java/thisisus/school/redis/Auth/exception/ExpiredTokenException.java
@@ -1,0 +1,10 @@
+package thisisus.school.redis.Auth.exception;
+
+import thisisus.school.common.exception.CustomException;
+import thisisus.school.common.exception.ExceptionCode;
+
+public class ExpiredTokenException extends CustomException {
+	public ExpiredTokenException() {
+		super(ExceptionCode.EXPIRED_TOKEN);
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/redis/Auth/repository/RefreshTokenRedisRepository.java
+++ b/BE/school/src/main/java/thisisus/school/redis/Auth/repository/RefreshTokenRedisRepository.java
@@ -1,0 +1,15 @@
+package thisisus.school.redis.Auth.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import thisisus.school.redis.Auth.domain.RefreshToken;
+import thisisus.school.redis.common.CommonRedisRepository;
+
+@Repository
+public class RefreshTokenRedisRepository extends CommonRedisRepository<RefreshToken> {
+
+	public RefreshTokenRedisRepository(RedisTemplate redisTemplate) {
+		this.redisTemplate = redisTemplate;
+	}
+}

--- a/BE/school/src/main/java/thisisus/school/redis/Auth/service/RefreshTokenRedisService.java
+++ b/BE/school/src/main/java/thisisus/school/redis/Auth/service/RefreshTokenRedisService.java
@@ -1,0 +1,10 @@
+package thisisus.school.redis.Auth.service;
+
+import thisisus.school.redis.Auth.domain.RefreshToken;
+
+public interface RefreshTokenRedisService {
+	void save(String token, Long memberId);
+	RefreshToken findByKey(String token);
+	void delete(String key);
+	void validateRefreshToken(String token);
+}

--- a/BE/school/src/main/java/thisisus/school/redis/Auth/service/RefreshTokenRedisServiceImpl.java
+++ b/BE/school/src/main/java/thisisus/school/redis/Auth/service/RefreshTokenRedisServiceImpl.java
@@ -1,0 +1,38 @@
+package thisisus.school.redis.Auth.service;
+
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+import thisisus.school.redis.Auth.domain.RefreshToken;
+import thisisus.school.redis.Auth.exception.ExpiredTokenException;
+import thisisus.school.redis.Auth.repository.RefreshTokenRedisRepository;
+
+@RequiredArgsConstructor
+@Service
+public class RefreshTokenRedisServiceImpl implements RefreshTokenRedisService {
+	private final RefreshTokenRedisRepository refreshTokenRedisRepository;
+
+	private final long REFRESH_TOKEN_TIME_TO_LIVE = 604800000L;
+
+	public void save(final String token, final Long memberId) {
+		RefreshToken refreshToken = RefreshToken.builder()
+			.refreshToken(token)
+			.memberId(memberId)
+			.build();
+		refreshTokenRedisRepository.save(token, refreshToken, REFRESH_TOKEN_TIME_TO_LIVE);
+	}
+
+	@Override
+	public RefreshToken findByKey(final String key) {
+		return refreshTokenRedisRepository.findByKey(key).get();
+	}
+
+
+	public void delete(final String key) {
+		refreshTokenRedisRepository.delete(key);
+	}
+
+	public void validateRefreshToken(final String key) {
+		refreshTokenRedisRepository.findByKey(key).orElseThrow(ExpiredTokenException::new);
+	}
+}


### PR DESCRIPTION
## #️⃣ 연관된 이슈 번호
close #33

## 📝 작업 내용
### Redis를 이용한 RefreshToken 관리
- Redis를 이용해서 RefreshToken 관리 기능을 추가했습니다.
- RefreshToken은 발행 후 7일 동안 유효하여 레디스에서도 동일하게 설정했습니다.
- 로그아웃 시 레디스에서 해당 refreshToken을 삭제합니다.
- 토큰 재발급 요청시 토큰이 유효한지 검사 후 재발급을 진행합니다.
![스크린샷 2024-07-20 오전 4 46 23](https://github.com/user-attachments/assets/e49010a4-67e5-45d8-bb83-ac13ce3bdd97)

### Redis를 이용한 OIDC Key 관리
- OIDC Key를 캐싱하는 기능을 추가했습니다.
- 하루 한번 외부에 요청할 수 있도록 캐시를 1일로 설정했습니다.
![image](https://github.com/user-attachments/assets/c0729613-5b65-485d-a667-784ed142335a)
![스크린샷 2024-07-20 오전 4 45 46](https://github.com/user-attachments/assets/4d3bb611-228a-4495-bd51-e503032d46fe)

## 💬 리뷰 요구사항

- 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
